### PR TITLE
feat: api 서버와 kafka 도커 환경에서 연동 완료

### DIFF
--- a/api_server/api_server.py
+++ b/api_server/api_server.py
@@ -1,5 +1,6 @@
 import logging
 import json
+import os
 import time
 from typing import Optional
 from contextlib import asynccontextmanager
@@ -10,12 +11,13 @@ from kafka.errors import KafkaError
 from google.cloud import storage
 
 # ----- 설정 -----
-GCS_KEY_PATH        = "/home/joon/keys/vocabulary-459105-5603cb550881.json"
+GCS_KEY_PATH        = os.environ.get("GCS_KEY_PATH")
 BUCKET_NAME         = "wh04-voc"
-NON_ARS_JSON_DIR    = "tmp/raw/consulting/"
-ARS_JSON_DIR        = "tmp/raw/ars/consulting/"
-AUDIO_DIR           = "tmp/raw/ars/audio/"
+NON_ARS_JSON_DIR    = "new/raw/consulting/"
+ARS_JSON_DIR        = "new/raw/ars/consulting/"
+AUDIO_DIR           = "new/raw/ars/audio/"
 
+BOOTSTRAP_SERVER    = "kafka:9093"
 TOPIC               = "voc-consulting-raw"
 MAX_RETRIES         = 3
 RETRY_BACKOFF_MS    = 500
@@ -50,7 +52,7 @@ async def lifespan(app: FastAPI):
         try:
             # Kafka Producer
             producer = KafkaProducer(
-                bootstrap_servers="kafka:9093",
+                bootstrap_servers=BOOTSTRAP_SERVER,
                 acks="all",
                 enable_idempotence=True,
                 retries=MAX_RETRIES,

--- a/api_server/api_server.py
+++ b/api_server/api_server.py
@@ -1,5 +1,6 @@
 import logging
 import json
+import time
 from typing import Optional
 from contextlib import asynccontextmanager
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,10 @@ services:
   api1:
     build:
       context: ./api_server
+    volumes:
+      - /home/joon/keys:/keys
+    env_file:
+      - .env
     environment:
       - APP_PORT=8888
       - KAFKA_BOOTSTRAP_SERVERS=kafka:9093
@@ -41,6 +45,10 @@ services:
   api2:
     build:
       context: ./api_server
+    volumes:
+      - /home/joon/keys:/keys
+    env_file:
+      - .env
     environment:
       - APP_PORT=8889
       - KAFKA_BOOTSTRAP_SERVERS=kafka:9093


### PR DESCRIPTION
- 도커 환경에서 kafka 서버와 api 서버 연동 완료.
- api 서버의 Kafka Producer에서 Kafka Broker에 정상적으로 연결.
- 외부에서 문의 데이터 POST 시, 서버에서 잘 받아오는 것 확인.